### PR TITLE
spelling, shell style

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -2,13 +2,13 @@
 set -e
 # credit: some of the code for this script inspired by https://github.com/lobaro/restic-backup-docker
 
-logFile=/var/log/restic/backup/`date +"%Y-%m-%d-%H-%M-%S"`.log
+logFile="/var/log/restic/backup/$(date +"%Y-%m-%d-%H-%M-%S").log"
 
-function log() {
-    echo "[$(date +"%Y-%m-%d %H:%M:%S")]$1" | tee -a $logFile
+log() {
+    echo "[$(date +"%Y-%m-%d %H:%M:%S")]$1" | tee -a "$logFile"
 }
 
-function showTime () {
+showTime() {
     num=$1
     min=0
     hour=0
@@ -35,7 +35,7 @@ function showTime () {
     log "[INFO] Total backup time: ${time}"
 }
 
-start=`date +%s`
+start=$(date +%s)
 log "[INFO] Starting backup"
 log "[INFO] Log filename: ${logFile}"
 
@@ -43,16 +43,16 @@ if [ -n "${RESTIC_BACKUP_ARGS}" ]; then
     log "[INFO] RESTIC_BACKUP_ARGS: ${RESTIC_BACKUP_ARGS}"
 fi
 
-restic backup /data ${RESTIC_BACKUP_ARGS} --tag=${RESTIC_TAG} | tee -a $logFile
+restic backup /data ${RESTIC_BACKUP_ARGS} --tag="${RESTIC_TAG}" | tee -a "$logFile"
 rc=$?
 if [[ $rc == 0 ]]; then
-    log "[INFO] Backup successfull"
+    log "[INFO] Backup succeeded"
 else
     log "[ERROR] Backup failed with status ${rc}"
     restic unlock
     copyErrorLog
     kill 1
 fi
-end=`date +%s`
+end=$(date +%s)
 log "[INFO] Finished backup at $(date)"
 showTime $((end-start))

--- a/forget.sh
+++ b/forget.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -e
 
-logFile=/var/log/restic/forget/`date +"%Y-%m-%d-%H-%M-%S"`.log
+logFile="/var/log/restic/forget/$(date +"%Y-%m-%d-%H-%M-%S").log"
 
-function log() {
-    echo "[$(date +"%Y-%m-%d %H:%M:%S")]$1" | tee -a $logFile
+log() {
+    echo "[$(date +"%Y-%m-%d %H:%M:%S")]$1" | tee -a "$logFile"
 }
 
-function showTime () {
+showTime () {
     num=$1
     min=0
     hour=0
@@ -34,24 +34,22 @@ function showTime () {
     log "[INFO] Total forget time: ${time}"
 }
 
-start=`date +%s`
+start=$(date +%s)
 log "[INFO] Starting forget"
 log "[INFO] Log filename: ${logFile}"
 log "[INFO] RESTIC_FORGET_ARGS: ${RESTIC_FORGET_ARGS}"
 
 if [ -n "${RESTIC_FORGET_ARGS}" ]; then
-    start=`date +%s`
-    restic forget ${RESTIC_FORGET_ARGS} | tee -a $logFile
+    restic forget ${RESTIC_FORGET_ARGS} | tee -a "$logFile"
     rc=$?
-    end=`date +%s`
     if [[ $rc == 0 ]]; then
-        log "[INFO] Forget successfull"
+        log "[INFO] Forget succeeded"
     else
-        log "[ERROR] Forget failed with status ${$rc}"
+        log "[ERROR] Forget failed with status $rc"
         restic unlock
     fi
 fi
 
-end=`date +%s`
+end=$(date +%s)
 log "[INFO] Finished forget at $(date)"
 showTime $((end-start))

--- a/prune.sh
+++ b/prune.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -e
 
-logFile=/var/log/restic/prune/`date +"%Y-%m-%d-%H-%M-%S"`.log
+logFile="/var/log/restic/prune/$(date +"%Y-%m-%d-%H-%M-%S").log"
 
-function log() {
-    echo "[$(date +"%Y-%m-%d %H:%M:%S")]$1" | tee -a $logFile
+log() {
+    echo "[$(date +"%Y-%m-%d %H:%M:%S")]$1" | tee -a "$logFile"
 }
 
-function showTime () {
+showTime() {
     num=$1
     min=0
     hour=0
@@ -34,22 +34,20 @@ function showTime () {
     log "[INFO] Total prune time: ${time}"
 }
 
-start=`date +%s`
+start=$(date +%s)
 log "[INFO] Starting prune"
 log "[INFO] Log filename: ${logFile}"
 
-start=`date +%s`
 log "[INFO] Starting prune process"
-restic prune | tee -a $logFile
+restic prune | tee -a "$logFile"
 rc=$?
-end=`date +%s`
 if [[ $rc == 0 ]]; then
-    log "[INFO] Prune Successfull"
+    log "[INFO] Prune succeeded"
 else
-    log "[ERROR] Prune failed with status ${$rc}"
+    log "[ERROR] Prune failed with status $rc"
     restic unlock
 fi
 
-end=`date +%s`
+end=$(date +%s)
 log "[INFO] Finished prune at $(date)"
 showTime $((end-start))


### PR DESCRIPTION
- s/successfull/succeeded past tense to match "failed"
- don't need `function` keyword
- fix timing end/start
- use modern bash `$()` processes and quotes