### PR TITLE
Prevent multiple `restic backup`s from running at once

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV RESTIC_TAG=latest
 RUN apk add --update --no-cache ca-certificates fuse openssh-client bash tzdata
 WORKDIR /root
 COPY --from=build /usr/local/src/restic/restic /usr/local/bin
-COPY entrypoint.sh backup.sh prune.sh forget.sh ./
+COPY entrypoint.sh backup.sh do_backup.sh prune.sh forget.sh ./
 ENV PATH="./:${PATH}"
 RUN chmod a+x ./*.sh
 RUN mkdir -p /var/spool/cron/crontabs \

--- a/backup.sh
+++ b/backup.sh
@@ -8,51 +8,9 @@ log() {
     echo "[$(date +"%Y-%m-%d %H:%M:%S")]$1" | tee -a "$logFile"
 }
 
-showTime() {
-    num=$1
-    min=0
-    hour=0
-    day=0
-    if((num>59));then
-        ((sec=num%60))
-        ((num=num/60))
-        if((num>59));then
-            ((min=num%60))
-            ((num=num/60))
-            if((num>23));then
-                ((hour=num%24))
-                ((day=num/24))
-            else
-                ((hour=num))
-            fi
-        else
-            ((min=num))
-        fi
-    else
-        ((sec=num))
-    fi
-    time="${day}d ${hour}h ${min}m ${sec}s"
-    log "[INFO] Total backup time: ${time}"
-}
-
-start=$(date +%s)
-log "[INFO] Starting backup"
-log "[INFO] Log filename: ${logFile}"
-
-if [ -n "${RESTIC_BACKUP_ARGS}" ]; then
-    log "[INFO] RESTIC_BACKUP_ARGS: ${RESTIC_BACKUP_ARGS}"
-fi
-
-restic backup /data ${RESTIC_BACKUP_ARGS} --tag="${RESTIC_TAG}" | tee -a "$logFile"
+flock -xn /root/restic.lock /root/do_backup.sh
 rc=$?
-if [[ $rc == 0 ]]; then
-    log "[INFO] Backup succeeded"
-else
-    log "[ERROR] Backup failed with status ${rc}"
-    restic unlock
-    copyErrorLog
-    kill 1
+if [[ $rc != 0 ]]; then
+	log "[INFO] Backup already running. Exiting"
 fi
-end=$(date +%s)
-log "[INFO] Finished backup at $(date)"
-showTime $((end-start))
+

--- a/do_backup.sh
+++ b/do_backup.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+# credit: some of the code for this script inspired by https://github.com/lobaro/restic-backup-docker
+
+logFile="/var/log/restic/backup/$(date +"%Y-%m-%d-%H-%M-%S").log"
+
+log() {
+    echo "[$(date +"%Y-%m-%d %H:%M:%S")]$1" | tee -a "$logFile"
+}
+
+showTime() {
+    num=$1
+    min=0
+    hour=0
+    day=0
+    if((num>59));then
+        ((sec=num%60))
+        ((num=num/60))
+        if((num>59));then
+            ((min=num%60))
+            ((num=num/60))
+            if((num>23));then
+                ((hour=num%24))
+                ((day=num/24))
+            else
+                ((hour=num))
+            fi
+        else
+            ((min=num))
+        fi
+    else
+        ((sec=num))
+    fi
+    time="${day}d ${hour}h ${min}m ${sec}s"
+    log "[INFO] Total backup time: ${time}"
+}
+
+start=$(date +%s)
+log "[INFO] Starting backup"
+log "[INFO] Log filename: ${logFile}"
+
+if [ -n "${RESTIC_BACKUP_ARGS}" ]; then
+    log "[INFO] RESTIC_BACKUP_ARGS: ${RESTIC_BACKUP_ARGS}"
+fi
+
+restic backup /data ${RESTIC_BACKUP_ARGS} --tag="${RESTIC_TAG}" | tee -a "$logFile"
+rc=$?
+if [[ $rc == 0 ]]; then
+    log "[INFO] Backup succeeded"
+else
+    log "[ERROR] Backup failed with status ${rc}"
+    restic unlock
+    copyErrorLog
+    kill 1
+fi
+end=$(date +%s)
+log "[INFO] Finished backup at $(date)"
+showTime $((end-start))


### PR DESCRIPTION
I'm doing an initial backup of ~2.5TB which is far more than my home bandwidth can upload offsite in a 24 hour period.  I noticed on the 2nd day of running, cron had launched a second `restic backup` process.  Per comments in this issue thread in the Restic repo, https://github.com/restic/restic/issues/519#issuecomment-269347162, it's not necessarily an issue to have multiple Restic backups of the same data going on at once, however it will waste some space.  

Rather than wasting space on B2 and using additional system resources on a resource constrained system, I made the following modifications:

* Moved backup.sh -> do_backup.sh
* Create new backup.sh that uses flock to ensure only a single instance of `do_backup.sh` is launched, and therefore only a single `restic backup` is launched as well.
